### PR TITLE
changed arguments for ssh2.sftp

### DIFF
--- a/scripts/sync.php
+++ b/scripts/sync.php
@@ -410,7 +410,7 @@ function sync_server($id, $only_username = null, $preview = false) {
 			if(is_null($only_username) || $username == $only_username) {
 				try {
 					$remote_filename = "$keydir/$username";
-					$remote_entity = "ssh2.sftp://$sftp$remote_filename";
+					$remote_entity = "ssh2.sftp://" . intval($sftp) . $remote_filename;
 					$create = true;
 					if($keyfile['check']) {
 						$stream = ssh2_exec($connection, 'id '.escapeshellarg($username));


### PR DESCRIPTION
Bugfix for newer versions of PHP such as PHP 7.0.32-0ubuntu0.16.04.1
The problem was caused by the bug listed here https://bugs.php.net/bug.php?id=73597