### PR TITLE
Restricting arbitrary users from creating servers/groups

### DIFF
--- a/views/groups.php
+++ b/views/groups.php
@@ -15,7 +15,7 @@
 ## limitations under the License.
 ##
 
-if(isset($_POST['add_group'])) {
+if(isset($_POST['add_group']) && ($active_user->admin)) {
 	$name = trim($_POST['name']);
 	if(preg_match('|/|', $name)) {
 		$content = new PageSection('invalid_group_name');

--- a/views/servers.php
+++ b/views/servers.php
@@ -15,7 +15,7 @@
 ## limitations under the License.
 ##
 
-if(isset($_POST['add_server'])) {
+if(isset($_POST['add_server']) && ($active_user->admin)) {
 	$hostname = trim($_POST['hostname']);
 	if(!preg_match('|.*\..*\..*|', $hostname)) {
 		$content = new PageSection('invalid_hostname');


### PR DESCRIPTION
At the moment, arbitrary users are able to create servers/groups by forging their own POST call. This Patch limits both calls to administrators.