### PR TITLE
Adding public key expiration

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -14,6 +14,9 @@ timeout_util = GNU coreutils
 ; used on e.g. alpine
 ; timeout_util = BusyBox
 
+key_expiration_enabled = 0
+key_expiration_days = 180
+
 [security]
 ; It is important that SKA is able to verify that it has connected to the
 ; server that it expected to connect to (otherwise it could be tricked into

--- a/migrations/004.php
+++ b/migrations/004.php
@@ -1,0 +1,21 @@
+<?php
+$migration_name = 'Add key deprication to public key';
+
+// Removing duplicates
+$this->database->query("
+UPDATE `public_key` SET `fingerprint_sha256` = null where `fingerprint_sha256` IN (
+    SELECT `fingerprint_sha256` FROM `public_key` GROUP BY `fingerprint_sha256` HAVING COUNT(*) > 1
+)
+");
+
+$this->database->query("
+ALTER TABLE `public_key` ADD CONSTRAINT `public_key_fingerprint` UNIQUE (`fingerprint_sha256`)
+");
+
+$this->database->query("
+ALTER TABLE `public_key` ADD COLUMN `upload_date` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+");
+
+$this->database->query("
+ALTER TABLE `public_key` ADD COLUMN `active` BOOLEAN NOT NULL DEFAULT TRUE
+");

--- a/model/migrationdirectory.php
+++ b/model/migrationdirectory.php
@@ -22,7 +22,7 @@ class MigrationDirectory extends DBDirectory {
 	/**
 	* Increment this constant to activate a new migration from the migrations directory
 	*/
-	const LAST_MIGRATION = 3;
+	const LAST_MIGRATION = 4;
 
 	public function __construct() {
 		parent::__construct();

--- a/model/publickey.php
+++ b/model/publickey.php
@@ -63,6 +63,7 @@ class PublicKey extends Record {
 		$this->fingerprint_sha256 = rtrim(base64_encode($hash_sha256), '=');
 		$this->randomart_md5 = $this->generate_randomart($hash_md5, "{$algorithm} {$this->keysize}", 'MD5');
 		$this->randomart_sha256 = $this->generate_randomart(bin2hex($hash_sha256), "{$algorithm} {$this->keysize}", 'SHA256');
+		$this->upload_date = date('Y-m-d H:i:s', time());
 
 		if($this->keysize < $minbits && !$force) {
 			throw new InvalidArgumentException("Insufficient bits in public key");

--- a/model/publickeydirectory.php
+++ b/model/publickeydirectory.php
@@ -30,7 +30,7 @@ class PublicKeyDirectory extends DBDirectory {
 			SELECT public_key.*, entity.type AS entity_type
 			FROM public_key
 			INNER JOIN entity ON entity.id = public_key.entity_id
-			WHERE public_key.id = ?
+			WHERE public_key.id = ? AND active = true
 		");
 		$stmt->bind_param('d', $id);
 		$stmt->execute();
@@ -60,6 +60,7 @@ class PublicKeyDirectory extends DBDirectory {
 		$fields = array("public_key.*, entity.type AS entity_type");
 		$joins = array();
 		$where = array();
+		$where[] = "public_key.active = true";
 		foreach($filter as $field => $value) {
 			if($value) {
 				switch($field) {

--- a/pagesection.php
+++ b/pagesection.php
@@ -66,6 +66,10 @@ class PageSection {
 			return null;
 		}
 	}
+	public function config() {
+		global $config;
+		return $config;
+	}
 	public function generate() {
 		ob_start();
 		$data = $this->data;

--- a/templates/functions.php
+++ b/templates/functions.php
@@ -178,6 +178,7 @@ function pubkey_json($pubkey, $include_keydata = true, $include_owner = true) {
 	$json->fingerprint = $pubkey->fingerprint_md5;
 	$json->fingerprint_md5 = $pubkey->fingerprint_md5;
 	$json->fingerprint_sha256 = $pubkey->fingerprint_sha256;
+	$json->upload_date = $pubkey->upload_date;
 	if($include_owner) {
 		$json->owner = new StdClass;
 		$json->owner->type = get_class($pubkey->owner);

--- a/templates/pubkey.php
+++ b/templates/pubkey.php
@@ -58,6 +58,20 @@ $owner = $this->get('pubkey')->owner;
 			<dd><?php out($this->get('pubkey')->fingerprint_sha256)?></dd>
 			<dt>Randomart (SHA256)</dt>
 			<dd><pre class="ascii-art"><?php out($this->get('pubkey')->randomart_sha256)?></pre></dd>
+			<dt>Upload Date</dt>
+			<dd><?php out($this->get('pubkey')->upload_date) ?></dd>
+			<?php if($this->config()['general']['key_expiration_enabled'] == 1) { ?>
+			<dt>Expiration Date</dt>
+			<dd>
+			<?php 
+			$date = $this->get('pubkey')->upload_date;
+			$expiration_days = $this->config()['general']['key_expiration_days'];
+			$expiration_date = strtotime($date . ' + ' . $expiration_days . ' days');
+			$expiration_time_in_days = round(($expiration_date - time()) / (60 * 60 * 24));
+			out(date('Y-m-d H:i:s', $expiration_date) . ' (' . $expiration_time_in_days . ' days left)');
+			?>
+			</dd>
+			<?php } ?>
 		</dl>
 	</div>
 	<?php if($this->get('user_is_owner') || $this->get('admin')) { ?>

--- a/templates/user_pubkeys.php
+++ b/templates/user_pubkeys.php
@@ -27,6 +27,20 @@
 		<dd><?php out($pubkey->fingerprint_md5)?></dd>
 		<dt>Fingerprint (SHA256)</dt>
 		<dd><?php out($pubkey->fingerprint_sha256)?></dd>
+		<dt>Upload Date</dt>
+		<dd><?php out($pubkey->upload_date) ?></dd>
+		<?php if($this->config()['general']['key_expiration_enabled'] == 1) { ?>
+		<dt>Expiration Date</dt>
+		<dd>
+		<?php 
+		$date = $pubkey->upload_date;
+		$expiration_days = $this->config()['general']['key_expiration_days'];
+		$expiration_date = strtotime($date . ' + ' . $expiration_days . ' days');
+		$expiration_time_in_days = round(($expiration_date - time()) / (60 * 60 * 24));
+		out(date('Y-m-d H:i:s', $expiration_date) . ' (' . $expiration_time_in_days . ' days left)');
+		?>
+		</dd>
+		<?php } ?>
 	</dl>
 </div>
 <?php } ?>

--- a/views/home.php
+++ b/views/home.php
@@ -33,6 +33,9 @@ if(isset($_POST['add_public_key'])) {
 		default:
 			$content->set('message', "The public key you submitted doesn't look valid.");
 		}
+	} catch(PublicKeyAlreadyKnownException $e) {
+		$content = new PageSection('key_upload_fail');
+		$content->set('message', "The public key you submitted is already in use. Please create a new one.");
 	}
 } elseif(isset($_POST['delete_public_key'])) {
 	foreach($public_keys as $public_key) {

--- a/views/serveraccount.php
+++ b/views/serveraccount.php
@@ -146,6 +146,9 @@ if(isset($_POST['add_access']) && ($server_admin || $account_admin || $active_us
 		default:
 			$content->set('message', "The public key you submitted doesn't look valid.");
 		}
+	} catch(PublicKeyAlreadyKnownException $e) {
+		$content = new PageSection('key_upload_fail');
+		$content->set('message', "The public key you submitted is already in use. Please create a new one.");
 	}
 } elseif(isset($_POST['delete_public_key']) && ($server_admin || $account_admin || $active_user->admin)) {
 	foreach($pubkeys as $pubkey) {


### PR DESCRIPTION
I have some feature ideas which I would like to include in the official version if you folks are interested. Feel free to voice concerns or reject them if you do not believe them appropriate.

## Public Key Expiration

This patch adds an expiration functionality to public keys. The administrator is able to configure if and when public keys should expire. The ldap_update file (executed inside a cron job) checks every public key and sends emails out to users when the keys are close to expiration. It also deals with deleting expired keys. 

## Impact

To make sure that a person does not simply readd the same key, it is necessary to make the fingerprint_sha256 field unique and switch from deleting keys to only disabling them. To make sure that already deployed service are ready to migrate, all duplicate fingerprints are set to null to allow changing the column to unique.

The impact to existing users is, that from now on, the public key table would keep growing and keys are never completely removed. There is also a chance that existing keys are losing their fingerprint if they are used in multiple places (Two users sharing a key).