### PR TITLE
Adding local user managment

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -83,6 +83,7 @@ password = password
 database = ska-db
 
 [ldap]
+enabled = 0
 ; Address to connect to LDAP server
 host = ldaps://ldap.example.com:636
 ; Use StartTLS for connection security (recommended if using ldap:// instead

--- a/core.php
+++ b/core.php
@@ -35,10 +35,12 @@ require('routes.php');
 require('ldap.php');
 require('email.php');
 
-$ldap_options = array();
-$ldap_options[LDAP_OPT_PROTOCOL_VERSION] = 3;
-$ldap_options[LDAP_OPT_REFERRALS] = !empty($config['ldap']['follow_referrals']);
-$ldap = new LDAP($config['ldap']['host'], $config['ldap']['starttls'], $config['ldap']['bind_dn'], $config['ldap']['bind_password'], $ldap_options);
+if ($config['ldap']['enabled'] == 1) {
+	$ldap_options = array();
+	$ldap_options[LDAP_OPT_PROTOCOL_VERSION] = 3;
+	$ldap_options[LDAP_OPT_REFERRALS] = !empty($config['ldap']['follow_referrals']);
+	$ldap = new LDAP($config['ldap']['host'], $config['ldap']['starttls'], $config['ldap']['bind_dn'], $config['ldap']['bind_password'], $ldap_options);
+}
 setup_database();
 
 $relative_frontend_base_url = (string)parse_url($config['web']['baseurl'], PHP_URL_PATH);

--- a/migrations/004.php
+++ b/migrations/004.php
@@ -1,0 +1,159 @@
+<?php
+$migration_name = 'Add local usermanagment';
+
+function free_results($database) {
+    do {
+        if ($res = $database->store_result()) {
+            $res->free();
+        }
+    } while ($database->more_results() && $database->next_result()); 
+}
+
+$this->database->autocommit(FALSE);
+
+$result = $this->database->query("
+    SELECT uid FROM user WHERE uid = 'keys-sync'
+");
+if ($result) {
+    if($result->num_rows === 0) {
+        $result->close();
+        $result = $this->database->multi_query("
+            INSERT INTO entity SET type = 'user';
+            INSERT INTO user SET entity_id = (
+                SELECT LAST_INSERT_ID()
+            ), uid = 'keys-sync', name = 'Synchronization script', email = '', auth_realm = 'local', admin = 1;
+        "); 
+        free_results($this->database);
+    } else {
+        $result->close();
+        $this->database->query("
+            UPDATE user SET auth_realm = 'local', active = 1 WHERE uid = 'keys-sync';
+        ");
+    }
+}
+
+
+$this->database->multi_query("
+CREATE TABLE `entity_event_2` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `entity_id` int(10) unsigned NOT NULL,
+    `actor_id` int(10) unsigned,
+    `date` datetime NOT NULL,
+    `details` mediumtext NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FK_entity_event_entity_id` (`entity_id`),
+    KEY `FK_entity_event_actor_id` (`actor_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT entity_event_2 SELECT * FROM entity_event;
+
+DROP TABLE entity_event;
+RENAME TABLE entity_event_2 TO entity_event;
+
+ALTER TABLE `entity_event`
+    ADD CONSTRAINT `FK_entity_event_actor_id` FOREIGN KEY (`actor_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL,
+    ADD CONSTRAINT `FK_entity_event_entity_id` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE;
+");
+free_results($this->database);
+
+
+$this->database->multi_query("
+CREATE TABLE `group_event_2` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `group` int(10) unsigned NOT NULL,
+    `entity_id` int(10) unsigned,
+    `date` datetime NOT NULL,
+    `details` mediumtext NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FK_group_event_group` (`group`),
+    KEY `FK_group_event_entity` (`entity_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=COMPACT;
+
+INSERT group_event_2 SELECT * FROM group_event;
+
+DROP TABLE group_event;
+RENAME TABLE group_event_2 TO group_event;
+
+ALTER TABLE `group_event`
+    ADD CONSTRAINT `FK_group_event_entity` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL,
+    ADD CONSTRAINT `FK_group_event_group` FOREIGN KEY (`group`) REFERENCES `group` (`entity_id`) ON DELETE CASCADE;
+");
+free_results($this->database);
+
+
+$this->database->multi_query("
+CREATE TABLE `group_member_2` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `group` int(10) unsigned NOT NULL,
+    `entity_id` int(10) unsigned NOT NULL,
+    `add_date` datetime NOT NULL,
+    `added_by` int(10) unsigned,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `group_entity_id` (`group`, `entity_id`),
+    KEY `FK_group_member_entity` (`entity_id`),
+    KEY `FK_group_member_entity_2` (`added_by`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=COMPACT;
+
+INSERT group_member_2 SELECT * FROM group_member;
+
+DROP TABLE group_member;
+RENAME TABLE group_member_2 TO group_member;
+
+ALTER TABLE `group_member`
+    ADD CONSTRAINT `FK_group_member_entity` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE CASCADE,
+    ADD CONSTRAINT `FK_group_member_entity_2` FOREIGN KEY (`added_by`) REFERENCES `entity` (`id`) ON DELETE SET NULL,
+    ADD CONSTRAINT `FK_group_member_group` FOREIGN KEY (`group`) REFERENCES `group` (`entity_id`) ON DELETE CASCADE
+");
+free_results($this->database);
+
+
+$this->database->multi_query("
+CREATE TABLE `server_event_2` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `server_id` int(10) unsigned NOT NULL,
+    `actor_id` int(10) unsigned,
+    `date` datetime NOT NULL,
+    `details` mediumtext NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FK_server_log_server` (`server_id`),
+    KEY `FK_server_event_actor_id` (`actor_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT server_event_2 SELECT * FROM server_event;
+
+DROP TABLE server_event;
+RENAME TABLE server_event_2 TO server_event;
+
+ALTER TABLE `server_event`
+    ADD CONSTRAINT `FK_server_event_actor_id` FOREIGN KEY (`actor_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL,
+    ADD CONSTRAINT `FK_server_log_server` FOREIGN KEY (`server_id`) REFERENCES `server` (`id`) ON DELETE CASCADE;
+");
+free_results($this->database);
+
+
+$this->database->multi_query("
+CREATE TABLE `server_note_2` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `server_id` int(10) unsigned NOT NULL,
+    `entity_id` int(10) unsigned,
+    `date` datetime NOT NULL,
+    `note` mediumtext NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FK_server_note_server` (`server_id`),
+    KEY `FK_server_note_user` (`entity_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT server_note_2 SELECT * FROM server_note;
+
+DROP TABLE server_note;
+RENAME TABLE server_note_2 TO server_note;
+
+ALTER TABLE `server_note`
+    ADD CONSTRAINT `FK_server_note_entity` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`id`) ON DELETE SET NULL,
+    ADD CONSTRAINT `FK_server_note_server` FOREIGN KEY (`server_id`) REFERENCES `server` (`id`) ON DELETE CASCADE
+");
+free_results($this->database);
+
+$this->database->commit();
+
+$this->database->autocommit(TRUE);

--- a/model/migrationdirectory.php
+++ b/model/migrationdirectory.php
@@ -22,7 +22,7 @@ class MigrationDirectory extends DBDirectory {
 	/**
 	* Increment this constant to activate a new migration from the migrations directory
 	*/
-	const LAST_MIGRATION = 3;
+	const LAST_MIGRATION = 4;
 
 	public function __construct() {
 		parent::__construct();

--- a/model/user.php
+++ b/model/user.php
@@ -67,6 +67,23 @@ class User extends Entity {
 	}
 
 	/**
+	* Delete the given user.
+	*/
+	public function delete() {
+		if(is_null($this->entity_id)) throw new BadMethodCallException('User must be in directory before it can be removed');
+		$stmt = $this->database->prepare("DELETE FROM entity WHERE id = ?");
+		$stmt->bind_param('d', $this->entity_id);
+		$stmt->execute();
+		$stmt->close();
+		$stmt = $this->database->prepare("DELETE FROM user WHERE entity_id = ?");
+		$stmt->bind_param('d', $this->entity_id);
+		$stmt->execute();
+		$stmt->close();
+		
+		$this->sync_remote_access();
+	}
+
+	/**
 	* Magic getter method - if superior field requested, return User object of user's superior
 	* @param string $field to retrieve
 	* @return mixed data stored in field

--- a/scripts/ldap_update.php
+++ b/scripts/ldap_update.php
@@ -29,22 +29,28 @@ try {
 	$active_user->uid = 'keys-sync';
 	$active_user->name = 'Synchronization script';
 	$active_user->email = '';
+	$active_user->auth_realm = 'local';
 	$active_user->active = 1;
 	$active_user->admin = 1;
 	$active_user->developer = 0;
 	$user_dir->add_user($active_user);
 }
 
-try {
-	$sysgrp = $group_dir->get_group_by_name($config['ldap']['admin_group_cn']);
-} catch(GroupNotFoundException $e) {
-	$sysgrp = new Group;
-	$sysgrp->name = $config['ldap']['admin_group_cn'];
-	$sysgrp->system = 1;
-	$group_dir->add_group($sysgrp);
+$ldap_enabled = $config['ldap']['enabled'];
+
+if($ldap_enabled == 1) {
+	try {
+		$sysgrp = $group_dir->get_group_by_name($config['ldap']['admin_group_cn']);
+	} catch(GroupNotFoundException $e) {
+		$sysgrp = new Group;
+		$sysgrp->name = $config['ldap']['admin_group_cn'];
+		$sysgrp->system = 1;
+		$group_dir->add_group($sysgrp);
+	}
 }
+
 foreach($users as $user) {
-	if($user->auth_realm == 'LDAP') {
+	if($user->auth_realm == 'LDAP' && $ldap_enabled == 1) {
 		$active = $user->active;
 		try {
 			$user->get_details_from_ldap();

--- a/scripts/sync.php
+++ b/scripts/sync.php
@@ -69,6 +69,7 @@ try {
 	$active_user->uid = 'keys-sync';
 	$active_user->name = 'Synchronization script';
 	$active_user->email = '';
+	$active_user->auth_realm = 'local';
 	$active_user->active = 1;
 	$active_user->admin = 1;
 	$active_user->developer = 0;

--- a/templates/functions.php
+++ b/templates/functions.php
@@ -85,7 +85,11 @@ function show_event($event) {
 			<a href="<?php outurl('/groups/'.urlencode($event->group->name))?>" class="group"><?php out($event->group->name) ?></a>
 			<?php } ?>
 		</td>
+		<?php if(is_null($event->actor->uid)) { ?>
+		<td>removed</td>
+		<?php } else { ?>
 		<td><a href="<?php outurl('/users/'.urlencode($event->actor->uid))?>" class="user"><?php out($event->actor->uid) ?></a></td>
+		<?php } ?>
 		<td><?php out($details, ESC_NONE) ?></td>
 		<td class="nowrap"><?php out($event->date) ?></td>
 	</tr>

--- a/templates/group.php
+++ b/templates/group.php
@@ -82,7 +82,7 @@ foreach($this->get('group_members') as $member) {
 							break;
 						}
 						?>
-						<td>Added on <?php out($member->add_date) ?> by <a href="<?php outurl('/users/'.urlencode($member->added_by->uid))?>" class="user"><?php out($member->added_by->uid) ?></a></td>
+						<td>Added on <?php out($member->add_date) ?> by <?php if(is_null($member->added_by->uid)) { ?>removed<?php } else { ?><a href="<?php outurl('/users/'.urlencode($member->added_by->uid))?>" class="user"><?php out($member->added_by->uid) ?></a><?php } ?></td>
 						<?php if(!$this->get('group')->system) { ?>
 						<td>
 							<button type="submit" name="delete_member" value="<?php out($member->entity_id)?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-ban-circle"></span> Remove from group</button>

--- a/templates/server.php
+++ b/templates/server.php
@@ -451,7 +451,7 @@
 			<div class="panel panel-default">
 				<div class="panel-body pre-formatted"><?php out($this->get('output_formatter')->comment_format($note->note), ESC_NONE)?></div>
 				<div class="panel-footer">
-					Added <?php out($note->date)?> by <?php out($note->user->name)?>
+					Added <?php out($note->date)?> by <?php if(is_null($note->user->uid)) { ?>removed<?php } else { ?><a href="<?php outurl('/users/'.urlencode($note->user->uid))?>" class="user"><?php out($note->user->uid) ?></a><?php } ?>
 					<button name="delete_note" value="<?php out($note->id)?>" class="pull-right btn btn-default btn-xs"><span class="glyphicon glyphicon-trash"></span> Delete</button>
 				</div>
 			</div>

--- a/templates/user.php
+++ b/templates/user.php
@@ -217,6 +217,17 @@
 		</form>
 		<?php } ?>
 		<?php } ?>
+		<?php if($this->get('user')->auth_realm == 'local' && $this->get('admin')) { ?>
+		<h3>User managment</h3>
+		<form method="post" action="<?php outurl($this->data->relative_request_url)?>" class="form-horizontal">
+			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
+			<div class="form-group">
+				<div class="col-sm-2">
+					<button type="submit" name="delete_user" value="1" class="btn btn-primary">Delete user</button>
+				</div>
+			</div>
+		</form>
+		<?php } ?>
 	</div>
 	<?php if($this->get('user')->auth_realm == 'LDAP') { ?>
 	<div class="tab-pane fade" id="settings">

--- a/templates/users.php
+++ b/templates/users.php
@@ -16,21 +16,59 @@
 ##
 ?>
 <h1>Users</h1>
-<table class="table">
-	<thead>
-		<tr>
-			<th>Username</th>
-			<th>Full name</th>
-			<th>Public keys</th>
-		</tr>
-	</thead>
-	<tbody>
-		<?php foreach($this->get('users') as $user) { ?>
-		<tr<?php if(!$user->active) out(' class="text-muted"', ESC_NONE) ?>>
-			<td><a href="<?php outurl('/users/'.urlencode($user->uid))?>" class="user<?php if(!$user->active) out(' text-muted') ?>"><?php out($user->uid)?></a></td>
-			<td><?php out($user->name)?></td>
-			<td><?php out(number_format(count($user->list_public_keys())))?></td>
-		</tr>
-		<?php } ?>
-	</tbody>
-</table>
+<?php if($this->get('admin')) { ?>
+<ul class="nav nav-tabs">
+	<li><a href="#list" data-toggle="tab">User list</a></li>
+	<li><a href="#add" data-toggle="tab">Add user</a></li>
+</ul>
+<?php } ?>
+
+
+<!-- Tab panes -->
+<div class="tab-content">
+	<div class="tab-pane fade<?php if(!$this->get('admin')) out(' in active') ?>" id="list">
+		<h2 class="sr-only">User list</h2>
+		<p><?php $total = count($this->get('users')); out(number_format($total).' user'.($total == 1 ? '' : 's').' found')?></p>
+		<table class="table table-hover table-condensed">
+			<thead>
+				<tr>
+					<th>Username</th>
+					<th>Full name</th>
+					<th>Public keys</th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach($this->get('users') as $user) { ?>
+				<tr<?php if(!$user->active) out(' class="text-muted"', ESC_NONE) ?>>
+					<td><a href="<?php outurl('/users/'.urlencode($user->uid))?>" class="user<?php if(!$user->active) out(' text-muted') ?>"><?php out($user->uid)?></a></td>
+					<td><?php out($user->name)?></td>
+					<td><?php out(number_format(count($user->list_public_keys())))?></td>
+				</tr>
+				<?php } ?>
+			</tbody>
+		</table>
+	</div>
+
+	<?php if($this->get('admin')) { ?>
+	<div class="tab-pane fade" id="add">
+		<h2 class="sr-only">Add user</h2>
+		<form method="post" action="<?php outurl($this->data->relative_request_url)?>">
+			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
+			<div class="form-group">
+				<label for="uid">Username</label>
+				<input type="text" id="uid" name="uid" class="form-control" required>
+			</div>
+			<div class="form-group">
+				<label for="name">Full Name</label>
+				<input type="text" id="name" name="name" class="form-control" required>
+			</div>
+			<div class="form-group">
+				<label for="email">Mail Address</label>
+				<input type="email" id="email" name="email" class="form-control" required>
+			</div>		
+			<input type="checkbox" name="admin" value="admin">Administrator<br><br>
+			<button type="submit" name="add_user" value="1" class="btn btn-primary">Add user</button>
+		</form>
+	</div>
+	<?php } ?>
+</div>

--- a/views/user.php
+++ b/views/user.php
@@ -48,9 +48,16 @@ if(isset($_POST['reassign_servers']) && is_array($_POST['servers']) && $active_u
 	}
 } elseif(isset($_POST['edit_user']) && $active_user->admin) {
 	$user->force_disable = $_POST['force_disable'];
-	$user->get_details_from_ldap();
+	if($active_user->auth_realm == 'LDAP' ) {
+		$user->get_details_from_ldap();
+	}
 	$user->update();
 	redirect('#settings');
+} elseif(isset($_POST['delete_user']) && $active_user->admin) {
+	if($user->auth_realm == 'local' && $user->uid != 'keys-sync' ) {
+		$user->delete();
+	}
+	redirect('/users');
 } else {
 	$content = new PageSection('user');
 	$content->set('user', $user);

--- a/views/users.php
+++ b/views/users.php
@@ -15,10 +15,44 @@
 ## limitations under the License.
 ##
 
-$content = new PageSection('users');
-$content->set('users', $user_dir->list_users());
-$content->set('admin', $active_user->admin);
+if(isset($_POST['add_user']) && $active_user->admin) {
+    $uid = trim($_POST['uid']);
+    $name = trim($_POST['name']);
+    $email = trim($_POST['email']);
+    
+    $user = new User;
+    $user->uid = $uid;
+    $user->name = $name;
+    $user->email = $email;
+    
+    $user->active = 1;
+    if (isset($_POST['admin']) && $_POST['admin'] === 'admin') {
+        $user->admin = 1;
+    } else {
+        $user->admin = 0;
+    }
+    $user->auth_realm = 'local';
 
+    try {
+        $user_dir->add_user($user);
+        $alert = new UserAlert;
+        $alert->content = 'User \'<a href="'.rrurl('/users/'.urlencode($user->uid)).'" class="alert-link">'.hesc($user->uid).'</a>\' successfully created.';
+        $alert->escaping = ESC_NONE;
+        $active_user->add_alert($alert);
+    } catch(UserAlreadyExistsException $e) {
+        $alert = new UserAlert;
+        $alert->content = 'User \'<a href="'.rrurl('/users/'.urlencode($user->uid)).'" class="alert-link">'.hesc($user->uid).'</a>\' is already known by SSH Key Authority.';
+        $alert->escaping = ESC_NONE;
+        $alert->class = 'danger';
+        $active_user->add_alert($alert);
+    }
+    redirect('#add');
+} else {
+    $content = new PageSection('users');
+    $content->set('users', $user_dir->list_users());
+    $content->set('admin', $active_user->admin);
+}
+    
 $page = new PageSection('base');
 $page->set('title', 'Users');
 $page->set('content', $content);


### PR DESCRIPTION
* keys-sync user becomes a local and not an ldap user
* local users are allowed to access site without 403
* LDAP can be dis/enabled in the configuration
* Added section to delete local user
* Added section to add local users
* Added graceful handling of deleted users in logs, nodes, ...

There are tables containing NOT NULL fields for actors
like the log table, which contains who did something.
When we remove a user, we don't want to remove that log
as the entity it is for is still alive. We instead want
to remove the actor (or set it to null) so that the
database stays consistent. The migrations in this patch
recreate every table which has an actor to allow NULL
fields. It also corrects a few constraints to set those
values to NULL on delete.

Resolves: #21
Resolves: #25
Resolves: #28