### PR TITLE
Allow the user to connect ldap groups

### DIFF
--- a/ldap.php
+++ b/ldap.php
@@ -46,7 +46,14 @@ class LDAP {
 		}
 	}
 
-	private static function decode_guid($encoded) {
+	/**
+	 * Decode a raw binary 16-byte guid (as given by ldap) to a readable
+	 * guid string like 0d187752-3d90-4c9c-8db2-eb7003163a82
+	 *
+	 * @param string $encoded
+	 * @return string
+	 */
+	private static function decode_guid(string $encoded) {
 		return bin2hex(strrev(substr($encoded, 0, 4))) . '-' .
 				bin2hex(strrev(substr($encoded, 4, 2))) . '-' .
 				bin2hex(strrev(substr($encoded, 6, 2))) . '-' .

--- a/ldap.php
+++ b/ldap.php
@@ -46,6 +46,14 @@ class LDAP {
 		}
 	}
 
+	private function decode_guid($encoded) {
+		return bin2hex(strrev(substr($encoded, 0, 4))) . '-' .
+				bin2hex(strrev(substr($encoded, 4, 2))) . '-' .
+				bin2hex(strrev(substr($encoded, 6, 2))) . '-' .
+				bin2hex(substr($encoded, 8, 2)) . '-' .
+				bin2hex(substr($encoded, 10, 6));
+	}
+
 	public function search($basedn, $filter, $fields = array(), $sort = array()) {
 		if(is_null($this->conn)) $this->connect();
 		if(empty($fields)) $r = @ldap_search($this->conn, $basedn, $filter);
@@ -67,6 +75,9 @@ class LDAP {
 						if(is_array($values)) {
 							unset($values['count']);
 							if(count($values) == 1) $values = $values[0];
+						}
+						if (strtolower($key) === 'objectguid') {
+							$values = self::decode_guid($values);
 						}
 						$itemResult[$key] = $values;
 					}

--- a/migrations/004.php
+++ b/migrations/004.php
@@ -1,0 +1,7 @@
+<?php
+
+$migration_name = 'Add ldap_guid group column for system groups';
+
+$this->database->query("
+ALTER TABLE `group` ADD `ldap_guid` varchar(36) NULL
+");

--- a/model/groupdirectory.php
+++ b/model/groupdirectory.php
@@ -200,6 +200,19 @@ class GroupDirectory extends DBDirectory {
 		$stmt->close();
 		return $groups;
 	}
+
+	/**
+	 * Get a list of the groups that are managed by ldap. (visible as system=1 in the database)
+	 * The result of this function is cached for better performance.
+	 * @return Group[] The list of ldap groups
+	 */
+	public function get_sys_groups() {
+		static $sys_groups = null;
+		if ($sys_groups === null) {
+			$sys_groups = $this->list_groups([], ['system' => 1]);
+		}
+		return $sys_groups;
+	}
 }
 
 class GroupNotFoundException extends Exception {}

--- a/model/groupdirectory.php
+++ b/model/groupdirectory.php
@@ -27,13 +27,14 @@ class GroupDirectory extends DBDirectory {
 	public function add_group(Group $group) {
 		$name = $group->name;
 		$system = $group->system;
+		$ldap_guid = $group->ldap_guid;
 		$this->database->begin_transaction();
 		$stmt = $this->database->prepare("INSERT INTO entity SET type = 'group'");
 		$stmt->execute();
 		$group->entity_id = $stmt->insert_id;
 		$stmt->close();
-		$stmt = $this->database->prepare("INSERT INTO `group` SET entity_id = ?, name = ?, system = ?");
-		$stmt->bind_param('dsd', $group->entity_id, $name, $system);
+		$stmt = $this->database->prepare("INSERT INTO `group` SET entity_id = ?, name = ?, system = ?, ldap_guid = ?");
+		$stmt->bind_param('dsds', $group->entity_id, $name, $system, $ldap_guid);
 		try {
 			$stmt->execute();
 			$stmt->close();

--- a/model/groupdirectory.php
+++ b/model/groupdirectory.php
@@ -110,6 +110,9 @@ class GroupDirectory extends DBDirectory {
 				case 'active':
 					$where[] = "`group`.active IN (".implode(", ", array_map('intval', $value)).")";
 					break;
+				case 'system':
+					$where[] = "`group`.system = ".intval($value);
+					break;
 				case 'admin':
 					$where[] = "admin_filter.admin = ".intval($value);
 					$joins['adminfilter'] = "INNER JOIN entity_admin admin_filter ON admin_filter.entity_id = `group`.entity_id";

--- a/model/migrationdirectory.php
+++ b/model/migrationdirectory.php
@@ -22,7 +22,7 @@ class MigrationDirectory extends DBDirectory {
 	/**
 	* Increment this constant to activate a new migration from the migrations directory
 	*/
-	const LAST_MIGRATION = 3;
+	const LAST_MIGRATION = 4;
 
 	public function __construct() {
 		parent::__construct();

--- a/model/user.php
+++ b/model/user.php
@@ -330,7 +330,7 @@ class User extends Entity {
 			}
 			$this->admin = 0;
 			$group_member = $ldapuser[strtolower($config['ldap']['group_member_value'])];
-			$ldapgroups = $this->ldap->search($config['ldap']['dn_group'], LDAP::escape($config['ldap']['group_member']).'='.LDAP::escape($group_member), array('cn', 'objectguid'));
+			$ldapgroups = $this->ldap->search($config['ldap']['dn_group'], LDAP::escape($config['ldap']['group_member']).':1.2.840.113556.1.4.1941:='.LDAP::escape($group_member), array('cn', 'objectguid'));
 			$ldap_group_guids = [];
 			foreach($ldapgroups as $ldapgroup) {
 				$ldap_group_guids[] = $ldapgroup['objectguid'];

--- a/model/user.php
+++ b/model/user.php
@@ -356,6 +356,22 @@ class User extends Entity {
 	}
 
 	/**
+	 * Adds the user to ldap groups or removes him from ldap groups, based on the current status on the directory server.
+	 */
+	public function update_group_memberships() {
+		global $group_dir;
+		foreach ($group_dir->get_sys_groups() as $sys_group) {
+			$should_be_member = $this->active && in_array(strtolower($sys_group->ldap_guid), $this->get_ldap_group_guids());
+			if ($should_be_member && !$this->member_of($sys_group)) {
+				$sys_group->add_member($this);
+			}
+			if (!$should_be_member && $this->member_of($sys_group)) {
+				$sys_group->delete_member($this);
+			}
+		}
+	}
+
+	/**
 	* Retrieve the user's superior from LDAP.
 	* @throws UserNotFoundException if the user is not found in LDAP
 	*/

--- a/model/user.php
+++ b/model/user.php
@@ -330,6 +330,7 @@ class User extends Entity {
 			}
 			$this->admin = 0;
 			$group_member = $ldapuser[strtolower($config['ldap']['group_member_value'])];
+			// The OID 1.2.840.113556.1.4.1941 queries the ldap server for direct and indirect memberships (groups in groups)
 			$ldapgroups = $this->ldap->search($config['ldap']['dn_group'], LDAP::escape($config['ldap']['group_member']).':1.2.840.113556.1.4.1941:='.LDAP::escape($group_member), array('cn', 'objectguid'));
 			$ldap_group_guids = [];
 			foreach($ldapgroups as $ldapgroup) {

--- a/model/userdirectory.php
+++ b/model/userdirectory.php
@@ -98,6 +98,7 @@ class UserDirectory extends DBDirectory {
 			$this->cache_uid[$uid] = $user;
 			$user->get_details_from_ldap();
 			$this->add_user($user);
+			$user->update_group_memberships();
 		}
 		$stmt->close();
 		return $user;

--- a/scripts/ldap_update.php
+++ b/scripts/ldap_update.php
@@ -21,19 +21,8 @@ require('../core.php');
 
 $users = $user_dir->list_users();
 
-// Use 'keys-sync' user as the active user (create if it does not yet exist)
-try {
-	$active_user = $user_dir->get_user_by_uid('keys-sync');
-} catch(UserNotFoundException $e) {
-	$active_user = new User;
-	$active_user->uid = 'keys-sync';
-	$active_user->name = 'Synchronization script';
-	$active_user->email = '';
-	$active_user->active = 1;
-	$active_user->admin = 1;
-	$active_user->developer = 0;
-	$user_dir->add_user($active_user);
-}
+// Use 'keys-sync' user as the active user
+$active_user = User::get_keys_sync_user();
 
 try {
 	$sysgrp = $group_dir->get_group_by_name($config['ldap']['admin_group_cn']);

--- a/scripts/ldap_update.php
+++ b/scripts/ldap_update.php
@@ -54,7 +54,6 @@ if ($sysgrp->ldap_guid === null) {
 	}
 }
 
-$sys_groups = $group_dir->list_groups([], ['system' => 1]);
 foreach($users as $user) {
 	if($user->auth_realm == 'LDAP') {
 		$active = $user->active;
@@ -100,15 +99,7 @@ foreach($users as $user) {
 				}
 			}
 		}
-		foreach ($sys_groups as $sys_group) {
-			$should_be_member = $user->active && in_array(strtolower($sys_group->ldap_guid), $user->get_ldap_group_guids());
-			if ($should_be_member && !$user->member_of($sys_group)) {
-				$sys_group->add_member($user);
-			}
-			if (!$should_be_member && $user->member_of($sys_group)) {
-				$sys_group->delete_member($user);
-			}
-		}
+		$user->update_group_memberships();
 		$user->update();
 	}
 }

--- a/templates/groups.php
+++ b/templates/groups.php
@@ -98,6 +98,7 @@
 	<?php if($this->get('admin')) { ?>
 	<div class="tab-pane fade" id="add">
 		<h2 class="sr-only">Add group</h2>
+		<h3>Create local group</h3>
 		<form method="post" action="<?php outurl($this->data->relative_request_url)?>" class="form-inline">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<div class="form-group">
@@ -114,6 +115,20 @@
 				</datalist>
 			</div>
 			<button type="submit" name="add_group" value="1" class="btn btn-primary">Create group</button>
+		</form>
+		<h3>Connect ldap group</h3>
+		<form method="post" action="<?php outurl($this->data->relative_request_url)?>" class="form-inline">
+			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
+			<div class="form-group">
+				<label for="name" class="sr-only">Group name</label>
+				<select id="ldap_group" name="ldap_group" class="form-control" required>
+					<option value="">-- Please choose a group --</option>
+					<?php foreach($this->get('all_ldap_groups') as $ldap_group) { ?>
+					<option value="<?php out($ldap_group['objectguid']) ?>"><?php out($ldap_group['samaccountname']) ?></option>
+					<?php } ?>
+				</select>
+			</div>
+			<button type="submit" name="add_ldap_group" value="1" class="btn btn-primary">Connect group</button>
 		</form>
 	</div>
 	<?php } ?>


### PR DESCRIPTION
This PR adds a new UI element "Connect ldap group" to "Groups" > "Add group" where you can select group names from the ldap server and connect them to SSH-Key-Authority.

Members of groups added this way are synced via ldap and can not be edited in the web frontend of SSH-Key-Authority.

The change was only tested using Microsoft Active Directory yet, so someone should first test this using other directory services before merging.