### PR TITLE
Add Support for MySQL TLS

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -81,6 +81,13 @@ port     = 3306
 username = ska-user
 password = password
 database = ska-db
+; The below options allow TLS encrypted MySQL Database Sessions
+;   usetls options:
+;     0: TLS is disabled
+;     1: TLS is enabled
+;   tls_ca_cert: Location for the TLS public key for the MySQL server
+usetls = 0
+tls_ca_cert = "/etc/ssl/certs/ca-certificates.crt"
 
 [ldap]
 ; Address to connect to LDAP server

--- a/core.php
+++ b/core.php
@@ -65,7 +65,14 @@ function autoload_model($classname) {
 function setup_database() {
 	global $config, $database, $driver, $pubkey_dir, $user_dir, $group_dir, $server_dir, $server_account_dir, $event_dir, $sync_request_dir;
 	try {
-		$database = new mysqli($config['database']['hostname'], $config['database']['username'], $config['database']['password'], $config['database']['database'], $config['database']['port']);
+		if ($config['database']['usetls']) {
+			$database = mysqli_init();
+			$database->options(MYSQLI_OPT_SSL_VERIFY_SERVER_CERT, true);
+			$database->ssl_set(NULL, NULL, $config['database']['tls_ca_cert'], NULL, NULL);
+			$database->real_connect($config['database']['hostname'], $config['database']['username'], $config['database']['password'], $config['database']['database'], $config['database']['port']);
+		} else {
+			$database = new mysqli($config['database']['hostname'], $config['database']['username'], $config['database']['password'], $config['database']['database'], $config['database']['port']);
+		}
 	} catch(ErrorException $e) {
 		throw new DBConnectionFailedException($e->getMessage());
 	}


### PR DESCRIPTION
This adds support for MySQL TLS support. Adds two additional configuration options under config.ini with documentation.