### PR TITLE
Remove inactive admins from servers.json

### DIFF
--- a/templates/servers_json.php
+++ b/templates/servers_json.php
@@ -26,7 +26,9 @@ foreach($this->get('servers') as $server) {
 	if($this->get('active_user')->admin) {
 		$jsonserver->admins = array();
 		foreach($server->list_effective_admins() as $admin) {
-			$jsonserver->admins[] = $admin->uid;
+			if($admin->active) {
+				$jsonserver->admins[] = $admin->uid;
+			}
 		}
 	}
 	if($last_sync_event) {


### PR DESCRIPTION
Currently all server administrators are listed in servers.json view. This PR is to remove inactive ones.

Signed-off-by: Franciszek Klajn <fklajn@opera.com>