### PR TITLE
Add functionality for normal users to view the full data of /servers.json

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -14,6 +14,14 @@ timeout_util = GNU coreutils
 ; used on e.g. alpine
 ; timeout_util = BusyBox
 
+; In some cases, a list of servers and their administrators are necessary to
+; be downloaded by a special user, without providing them full admin access.
+; These users can view the full servers_json file, including admins of
+; servers. Effectively, they are fake view-only admins for json lists.
+; The value should be the uid of the user.
+; fake_viewonly_admin[] = "fake-admin"
+
+
 [security]
 ; It is important that SKA is able to verify that it has connected to the
 ; server that it expected to connect to (otherwise it could be tricked into

--- a/templates/servers_json.php
+++ b/templates/servers_json.php
@@ -23,7 +23,9 @@ foreach($this->get('servers') as $server) {
 	$jsonserver->hostname = $server->hostname;
 	$jsonserver->key_management = $server->key_management;
 	$jsonserver->sync_status = $server->sync_status;
-	if($this->get('active_user')->admin) {
+	if($this->get('active_user')->admin ||
+		(isset($config['general']['fake_viewonly_admin']) && is_array($config['general']['fake_viewonly_admin']) && in_array($this->get('active_user')->uid, $config['general']['fake_viewonly_admin'], true))
+	)
 		$jsonserver->admins = array();
 		foreach($server->list_effective_admins() as $admin) {
 			if($admin->active) {


### PR DESCRIPTION
This patch provides the functionality of allowing certain accounts to view the full output of /servers.json, including server administrators.

Previously, the only users which could view this data in full were sysadmins, which does not comply with the least privilege principle of security (they are able to make changes to keys, while only needing to view read-only data).