### PR TITLE
Merge some of these changes

### DIFF
--- a/model/serveraccount.php
+++ b/model/serveraccount.php
@@ -51,9 +51,11 @@ class ServerAccount extends Entity {
 	public function update() {
 		global $config;
 		// Make it impossible to set default accounts to inactive
-		if(is_array($config['defaults']['account_groups'])) {
-			if(array_key_exists($this->data['name'], $config['defaults']['account_groups'])) {
-				$this->data['active'] = true;
+		if(isset($config['defaults']['account_groups'])){ # Fix null issue
+			if(is_array($config['defaults']['account_groups'])) {
+				if(array_key_exists($this->data['name'], $config['defaults']['account_groups'])) {
+					$this->data['active'] = true;
+				}
 			}
 		}
 		$changes = parent::update();

--- a/pagesection.php
+++ b/pagesection.php
@@ -39,6 +39,7 @@ class PageSection {
 			$this->data->menu_items['/tools'] = 'Tools';
 		}
 		$this->data->menu_items['/help'] = 'Help';
+		$this->data->menu_items['/logout'] = 'logout';
 		$this->data->relative_request_url = $relative_request_url;
 		$this->data->active_user = $active_user;
 		$this->data->web_config = $config['web'];

--- a/pagesection.php
+++ b/pagesection.php
@@ -39,7 +39,7 @@ class PageSection {
 			$this->data->menu_items['/tools'] = 'Tools';
 		}
 		$this->data->menu_items['/help'] = 'Help';
-		$this->data->menu_items['/logout'] = 'logout';
+		$this->data->menu_items['/logout'] = 'Logout';
 		$this->data->relative_request_url = $relative_request_url;
 		$this->data->active_user = $active_user;
 		$this->data->web_config = $config['web'];

--- a/routes.php
+++ b/routes.php
@@ -45,6 +45,7 @@ $routes = array(
 	'/users/{username}/pubkeys.{format}' => 'user_pubkeys',
 	'/users/{username}/pubkeys/{key}' => 'pubkey',
 	'/users/{username}/pubkeys/{key}.{format}' => 'pubkey',
+	'/logout' => 'logout'
 );
 
 $public_routes = array(

--- a/scripts/sync.php
+++ b/scripts/sync.php
@@ -213,7 +213,10 @@ function sync_server($id, $only_username = null, $preview = false) {
 					if(count($keys) > 0) {
 						if($user->active) {
 							foreach($keys as $key) {
-								$keyfile .= $prefix.$key->export()."\n";
+								if (!$key->list_destination_rules()){
+								}else{
+									$keyfile .= $prefix.$key->export()."\n";
+								}
 							}
 						} else {
 							$keyfile .= "# Inactive account\n";

--- a/templates/pubkey.php
+++ b/templates/pubkey.php
@@ -35,7 +35,7 @@ $owner = $this->get('pubkey')->owner;
 	}
 	?>
 </h1>
-<?php if($this->get('user_is_owner') || $this->get('admin')) { ?>
+<?php if($this->get('admin')) { ?>
 <ul class="nav nav-tabs">
 	<li><a href="#info" data-toggle="tab">Information</a></li>
 	<li><a href="#sig" data-toggle="tab">Key signing</a></li>

--- a/views/logout.php
+++ b/views/logout.php
@@ -1,0 +1,6 @@
+<script>
+var currentURL = window.location.href;
+var domain = currentURL.replace(/^https?:\/\/(?:www\.)?([^:/?]+).*/, "$1");
+var redirectURL = "http://log:out@" + domain;
+window.location.href = redirectURL;
+</script>


### PR DESCRIPTION
Resolves this issue: https://github.com/operasoftware/ssh-key-authority/issues/58

changes the ldap managed sync to not sync all keys all the time. should only sync if a rule exists to sync there.
Also prevent users from making their own rules.
only admins can create rules for users

Also fixes a null issue in models/serveraccount.php where in $config['defaults']['account_groups']
account_groups array doesn't exist