### PR TITLE
fix(auth): restrict group access rule option edits to admins

### DIFF
--- a/views/access_options.php
+++ b/views/access_options.php
@@ -49,6 +49,10 @@ if(isset($router->vars['hostname'])) {
 	try {
 		$group = $group_dir->get_group_by_name($router->vars['group']);
 		$group_admin = $active_user->admin_of($group);
+		if(!$active_user->admin && !$group_admin) {
+			require('views/error403.php');
+			die;
+		}
 		$access = $group->get_access_by_id($router->vars['access']);
 		$entity = $group;
 	} catch(GroupNotFoundException $e) {
@@ -64,6 +68,10 @@ if(isset($router->vars['hostname'])) {
 }
 if(isset($_POST['update_access'])) {
 	$options = array();
+	if (isset($group) && !$active_user->admin && !$group_admin) { // not really needed, just future-proofing
+		require('views/error403.php');
+		die;
+	}
 	if(isset($_POST['access_option'])) {
 		foreach($_POST['access_option'] as $k => $v) {
 			if($v['enabled']) {


### PR DESCRIPTION
Previously, /groups/{group}/access_rules/{id} accepted POSTs from any authenticated user, allowing them to overwrite SSH authorized_keys options for all group members, regardless of whether they are in the specified group or not. This exposed a privilege escalation vector and risk of access disruption.

Now enforce global admin or group admin before loading or updating group access rules, consistent with server-side access checks.

THANK YOU FOR YOUR ATTENTION.